### PR TITLE
test(e2e): 초기화 테스트에서 root 노드 width 검증 추가

### DIFF
--- a/e2e/tests/editor.spec.ts
+++ b/e2e/tests/editor.spec.ts
@@ -5,7 +5,7 @@ test.describe("에디터 초기화", () => {
 	test("Shell과 Canvas iframe이 Penpal로 연결되어 초기 노드가 렌더링된다", async ({ editor }) => {
 		await expect(editor.canvas.locator("#canvas-container")).toBeAttached()
 		await editor.layerRow("root").click()
-		await expect(editor.propW).toHaveValue("999")
+		await expect(editor.propW).toHaveValue("400")
 	})
 
 	test("레이어 패널에서 노드를 클릭하면 Properties 패널에 해당 노드 속성이 표시된다", async ({ editor }) => {


### PR DESCRIPTION
## Summary
- 에디터 초기화 테스트에서 root 노드 선택 후 width 값 검증 추가