### PR TITLE
Draft: Properties Panel: Per-side spacing (padding/margin)

### DIFF
--- a/packages/editor-core/src/codegen/serialize.ts
+++ b/packages/editor-core/src/codegen/serialize.ts
@@ -19,6 +19,12 @@ const DEFAULT_OPTIONS: Required<SerializeOptions> = {
 
 /**
  * CSSProperties를 inline style 문자열로 변환
+ *
+ * NOTE (#65): 이 함수는 모든 style 속성을 일반적으로 직렬화하므로
+ * paddingTop/Right/Bottom/Left, marginTop/Right/Bottom/Left 등
+ * 개별 방향 속성도 추가 작업 없이 자동으로 처리됩니다.
+ * 단, DesignTab에서 개별 값 전환 시 shorthand(padding/margin)를 제거하여
+ * shorthand와 개별 값이 동시에 출력되지 않도록 합니다.
  */
 function serializeStyle(style: Record<string, unknown>): string {
 	const entries = Object.entries(style).filter(([, value]) => value !== undefined)

--- a/packages/editor-shell/src/components/PropertiesPanel/DesignTab.tsx
+++ b/packages/editor-shell/src/components/PropertiesPanel/DesignTab.tsx
@@ -1,16 +1,73 @@
+import { useState } from "react"
 import type { SceneNode } from "@design-editor/core"
 
 import { useEditorStore } from "../../services/EditorContext"
+
+/**
+ * TODO (#65): 개별 방향 spacing 값이 존재하는지 확인하여 확장 모드 초기 상태를 결정
+ * paddingTop/Right/Bottom/Left 중 하나라도 설정되어 있으면 true 반환
+ */
+function hasPerSideValues(
+	style: Record<string, unknown>,
+	prefix: "padding" | "margin",
+): boolean {
+	return (
+		style[`${prefix}Top`] !== undefined ||
+		style[`${prefix}Right`] !== undefined ||
+		style[`${prefix}Bottom`] !== undefined ||
+		style[`${prefix}Left`] !== undefined
+	)
+}
 
 export function DesignTab({ node }: { node: SceneNode }) {
 	const updateNode = useEditorStore((state) => state.updateNode)
 	const moveNode = useEditorStore((state) => state.moveNode)
 	const style = node.style ?? {}
 
+	// TODO (#65): 개별 방향 모드 토글 상태
+	const [paddingExpanded, setPaddingExpanded] = useState(() => hasPerSideValues(style, "padding"))
+	const [marginExpanded, setMarginExpanded] = useState(() => hasPerSideValues(style, "margin"))
+
 	const handleStyleChange = (key: string, value: string | number | undefined) => {
 		updateNode(node.id, {
 			style: { ...style, [key]: value },
 		})
+	}
+
+	/**
+	 * TODO (#65): 단일 값 ↔ 개별 값 전환 핸들러
+	 * - 단일 → 개별: shorthand 값을 4방향에 복사 후 shorthand 제거
+	 * - 개별 → 단일: 4방향 값 제거 (shorthand는 사용자가 직접 입력)
+	 */
+	const handleTogglePerSide = (prefix: "padding" | "margin") => {
+		const isExpanding = prefix === "padding" ? !paddingExpanded : !marginExpanded
+		const currentShorthand = style[prefix]
+
+		if (isExpanding) {
+			// TODO (#65): 단일 값을 4방향으로 확장
+			// shorthand 값이 있으면 4방향 모두에 동일한 값을 설정하고 shorthand 제거
+			const newStyle = { ...style }
+			if (currentShorthand !== undefined) {
+				newStyle[`${prefix}Top`] = currentShorthand
+				newStyle[`${prefix}Right`] = currentShorthand
+				newStyle[`${prefix}Bottom`] = currentShorthand
+				newStyle[`${prefix}Left`] = currentShorthand
+			}
+			delete newStyle[prefix]
+			updateNode(node.id, { style: newStyle })
+		} else {
+			// TODO (#65): 개별 값을 단일 값으로 축소
+			// 4방향 값을 모두 제거 (사용자가 shorthand를 직접 입력)
+			const newStyle = { ...style }
+			delete newStyle[`${prefix}Top`]
+			delete newStyle[`${prefix}Right`]
+			delete newStyle[`${prefix}Bottom`]
+			delete newStyle[`${prefix}Left`]
+			updateNode(node.id, { style: newStyle })
+		}
+
+		if (prefix === "padding") setPaddingExpanded(!paddingExpanded)
+		else setMarginExpanded(!marginExpanded)
 	}
 
 	return (
@@ -199,29 +256,142 @@ export function DesignTab({ node }: { node: SceneNode }) {
 				</div>
 			</section>
 
-			{/* Spacing */}
+			{/* Spacing - Padding */}
 			<section className="property-section">
-				<h3 className="section-title">Spacing</h3>
-				<div className="property-grid">
-					<label>
-						<span>P</span>
-						<input
-							type="number"
-							placeholder="Padding"
-							value={style.padding ?? ""}
-							onChange={(e) => handleStyleChange("padding", e.target.value ? Number(e.target.value) : undefined)}
-						/>
-					</label>
-					<label>
-						<span>M</span>
-						<input
-							type="number"
-							placeholder="Margin"
-							value={style.margin ?? ""}
-							onChange={(e) => handleStyleChange("margin", e.target.value ? Number(e.target.value) : undefined)}
-						/>
-					</label>
+				<div className="section-title-row">
+					<h3 className="section-title">Padding</h3>
+					{/* TODO (#65): 단일/개별 전환 토글 버튼 */}
+					<button
+						className="spacing-toggle-btn"
+						title={paddingExpanded ? "단일 값으로 전환" : "개별 방향 설정"}
+						onClick={() => handleTogglePerSide("padding")}
+					>
+						{paddingExpanded ? "▪" : "⊞"}
+					</button>
 				</div>
+				{paddingExpanded ? (
+					/* TODO (#65): 4방향 개별 입력 UI */
+					<div className="spacing-per-side">
+						<label>
+							<span>T</span>
+							<input
+								type="number"
+								placeholder="Top"
+								value={style.paddingTop ?? ""}
+								onChange={(e) => handleStyleChange("paddingTop", e.target.value ? Number(e.target.value) : undefined)}
+							/>
+						</label>
+						<label>
+							<span>R</span>
+							<input
+								type="number"
+								placeholder="Right"
+								value={style.paddingRight ?? ""}
+								onChange={(e) => handleStyleChange("paddingRight", e.target.value ? Number(e.target.value) : undefined)}
+							/>
+						</label>
+						<label>
+							<span>B</span>
+							<input
+								type="number"
+								placeholder="Bottom"
+								value={style.paddingBottom ?? ""}
+								onChange={(e) => handleStyleChange("paddingBottom", e.target.value ? Number(e.target.value) : undefined)}
+							/>
+						</label>
+						<label>
+							<span>L</span>
+							<input
+								type="number"
+								placeholder="Left"
+								value={style.paddingLeft ?? ""}
+								onChange={(e) => handleStyleChange("paddingLeft", e.target.value ? Number(e.target.value) : undefined)}
+							/>
+						</label>
+					</div>
+				) : (
+					/* 기존 단일 입력 */
+					<div className="property-row">
+						<label>
+							<span>P</span>
+							<input
+								type="number"
+								placeholder="Padding"
+								value={style.padding ?? ""}
+								onChange={(e) => handleStyleChange("padding", e.target.value ? Number(e.target.value) : undefined)}
+							/>
+						</label>
+					</div>
+				)}
+			</section>
+
+			{/* Spacing - Margin */}
+			<section className="property-section">
+				<div className="section-title-row">
+					<h3 className="section-title">Margin</h3>
+					{/* TODO (#65): 단일/개별 전환 토글 버튼 */}
+					<button
+						className="spacing-toggle-btn"
+						title={marginExpanded ? "단일 값으로 전환" : "개별 방향 설정"}
+						onClick={() => handleTogglePerSide("margin")}
+					>
+						{marginExpanded ? "▪" : "⊞"}
+					</button>
+				</div>
+				{marginExpanded ? (
+					/* TODO (#65): 4방향 개별 입력 UI */
+					<div className="spacing-per-side">
+						<label>
+							<span>T</span>
+							<input
+								type="number"
+								placeholder="Top"
+								value={style.marginTop ?? ""}
+								onChange={(e) => handleStyleChange("marginTop", e.target.value ? Number(e.target.value) : undefined)}
+							/>
+						</label>
+						<label>
+							<span>R</span>
+							<input
+								type="number"
+								placeholder="Right"
+								value={style.marginRight ?? ""}
+								onChange={(e) => handleStyleChange("marginRight", e.target.value ? Number(e.target.value) : undefined)}
+							/>
+						</label>
+						<label>
+							<span>B</span>
+							<input
+								type="number"
+								placeholder="Bottom"
+								value={style.marginBottom ?? ""}
+								onChange={(e) => handleStyleChange("marginBottom", e.target.value ? Number(e.target.value) : undefined)}
+							/>
+						</label>
+						<label>
+							<span>L</span>
+							<input
+								type="number"
+								placeholder="Left"
+								value={style.marginLeft ?? ""}
+								onChange={(e) => handleStyleChange("marginLeft", e.target.value ? Number(e.target.value) : undefined)}
+							/>
+						</label>
+					</div>
+				) : (
+					/* 기존 단일 입력 */
+					<div className="property-row">
+						<label>
+							<span>M</span>
+							<input
+								type="number"
+								placeholder="Margin"
+								value={style.margin ?? ""}
+								onChange={(e) => handleStyleChange("margin", e.target.value ? Number(e.target.value) : undefined)}
+							/>
+						</label>
+					</div>
+				)}
 			</section>
 
 			{/* Fill */}

--- a/packages/editor-shell/src/components/PropertiesPanel/PropertiesPanel.css
+++ b/packages/editor-shell/src/components/PropertiesPanel/PropertiesPanel.css
@@ -130,6 +130,41 @@
 	border-color: #0d99ff;
 }
 
+/* TODO (#65): Per-side spacing UI styles */
+.section-title-row {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	margin-bottom: 8px;
+}
+
+.section-title-row .section-title {
+	margin-bottom: 0;
+}
+
+.spacing-toggle-btn {
+	padding: 2px 6px;
+	border: 1px solid #e0e0e0;
+	border-radius: 3px;
+	background-color: #f8f8f8;
+	color: #666666;
+	font-size: 11px;
+	cursor: pointer;
+	transition: all 0.15s;
+	line-height: 1;
+}
+
+.spacing-toggle-btn:hover {
+	background-color: #e8e8e8;
+	color: #1a1a1a;
+}
+
+.spacing-per-side {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: 6px;
+}
+
 .design-tab {
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION
## Summary
- Padding/Margin 섹션에 단일 값 ↔ 개별 방향(top/right/bottom/left) 전환 토글 버튼 추가
- 개별 방향 전환 시 shorthand 값을 4방향으로 복사 후 shorthand 제거하여 충돌 방지
- `serialize.ts`는 모든 CSS 속성을 일반적으로 직렬화하므로 추가 작업 불필요 확인

## 변경 파일
- `DesignTab.tsx`: 토글 상태 관리, 전환 로직, 4방향 입력 UI
- `PropertiesPanel.css`: 토글 버튼 및 4방향 그리드 레이아웃 스타일
- `serialize.ts`: 확인 주석 추가 (동작 변경 없음)

## Test plan
- [ ] 단일 padding 입력 → 값이 정상 반영되는지 확인
- [ ] 토글 클릭 → 4방향 입력 필드로 전환되는지 확인
- [ ] 단일 값(예: padding: 16) 상태에서 토글 → 4방향 모두 16으로 채워지는지 확인
- [ ] 개별 값 설정 후 토글 → shorthand로 돌아가고 개별 값이 제거되는지 확인
- [ ] margin도 동일하게 동작하는지 확인
- [ ] CodeTab에서 생성된 코드에 paddingTop 등 개별 속성이 정상 출력되는지 확인

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)