### PR TITLE
Draft: Properties Panel: Flex child properties (grow, shrink, basis, align-self)

### DIFF
--- a/packages/editor-core/src/types/editor.ts
+++ b/packages/editor-core/src/types/editor.ts
@@ -127,6 +127,9 @@ export interface EditorActions {
 	/** 노드 찾기 */
 	findNode: (id: string) => SceneNode | null
 
+	/** 부모 노드 찾기 */
+	findParentNode: (id: string) => SceneNode | null
+
 	/** 드래그 프리뷰 설정 */
 	setDragPreview: (preview: { nodeId: string; dx: number; dy: number } | null) => void
 

--- a/packages/editor-shell/src/components/PropertiesPanel/DesignTab.tsx
+++ b/packages/editor-shell/src/components/PropertiesPanel/DesignTab.tsx
@@ -5,7 +5,14 @@ import { useEditorStore } from "../../services/EditorContext"
 export function DesignTab({ node }: { node: SceneNode }) {
 	const updateNode = useEditorStore((state) => state.updateNode)
 	const moveNode = useEditorStore((state) => state.moveNode)
+	const findParentNode = useEditorStore((state) => state.findParentNode)
 	const style = node.style ?? {}
+
+	// TODO: Check if the selected node's parent has display: flex
+	// to conditionally show the Flex Child section
+	const parentNode = findParentNode(node.id)
+	const parentStyle = parentNode?.style ?? {}
+	const isFlexChild = parentStyle.display === "flex"
 
 	const handleStyleChange = (key: string, value: string | number | undefined) => {
 		updateNode(node.id, {
@@ -128,6 +135,78 @@ export function DesignTab({ node }: { node: SceneNode }) {
 					</>
 				)}
 			</section>
+
+			{/* Flex Child - shown when parent is display: flex */}
+			{/* TODO: Consider showing this section in a disabled state when not a flex child */}
+			{isFlexChild && (
+				<section className="property-section" data-testid="flex-child-section">
+					<h3 className="section-title">Flex Child</h3>
+					<div className="property-grid">
+						{/* TODO: Implement flexGrow number input (default: 0) */}
+						<label>
+							<span>Grow</span>
+							<input
+								data-testid="prop-flex-grow"
+								type="number"
+								min={0}
+								value={style.flexGrow ?? 0}
+								onChange={(e) => handleStyleChange("flexGrow", Number(e.target.value))}
+							/>
+						</label>
+						{/* TODO: Implement flexShrink number input (default: 1) */}
+						<label>
+							<span>Shrink</span>
+							<input
+								data-testid="prop-flex-shrink"
+								type="number"
+								min={0}
+								value={style.flexShrink ?? 1}
+								onChange={(e) => handleStyleChange("flexShrink", Number(e.target.value))}
+							/>
+						</label>
+					</div>
+					<div className="property-grid" style={{ marginTop: 8 }}>
+						{/* TODO: Implement flexBasis with support for px, %, and auto values */}
+						{/* TODO: Consider adding a unit selector (px / % / auto) */}
+						<label>
+							<span>Basis</span>
+							<input
+								data-testid="prop-flex-basis"
+								type="text"
+								placeholder="auto"
+								value={style.flexBasis ?? ""}
+								onChange={(e) => {
+									const val = e.target.value
+									if (val === "" || val === "auto") {
+										handleStyleChange("flexBasis", val === "" ? undefined : "auto")
+									} else {
+										// TODO: Parse and validate px/% values
+										handleStyleChange("flexBasis", val)
+									}
+								}}
+							/>
+						</label>
+						{/* TODO: Implement alignSelf dropdown */}
+						<label>
+							<span>Align</span>
+							<select
+								data-testid="prop-align-self"
+								value={style.alignSelf ?? "auto"}
+								onChange={(e) =>
+									handleStyleChange("alignSelf", e.target.value === "auto" ? undefined : e.target.value)
+								}
+							>
+								<option value="auto">Auto</option>
+								<option value="flex-start">Start</option>
+								<option value="center">Center</option>
+								<option value="flex-end">End</option>
+								<option value="stretch">Stretch</option>
+								<option value="baseline">Baseline</option>
+							</select>
+						</label>
+					</div>
+				</section>
+			)}
 
 			{/* CSS Position */}
 			<section className="property-section">

--- a/packages/editor-shell/src/store/editor.ts
+++ b/packages/editor-shell/src/store/editor.ts
@@ -542,6 +542,15 @@ export function createEditorStore() {
 					if (!page) return null
 					return findNode(page, id)
 				},
+
+				findParentNode(id: string): SceneNode | null {
+					const page = get().document.children.find((p) => p.id === get().currentPageId)
+					if (!page) return null
+					const parent = findParent(page, id)
+					// PageNode is not a SceneNode, so only return if it's a SceneNode (has 'type')
+					if (parent && "type" in parent) return parent as SceneNode
+					return null
+				},
 			})),
 		),
 	)


### PR DESCRIPTION
Closes #70

## Summary
- **`findParentNode` 유틸리티 추가** (`editor.ts` store + `EditorActions` 타입): 선택된 노드의 부모 노드를 조회하여 flex 컨텍스트 확인
- **Flex Child 섹션 추가** (`DesignTab.tsx`): 부모가 `display: flex`일 때 조건부 렌더링
  - `flexGrow` — 숫자 입력 (기본값: 0)
  - `flexShrink` — 숫자 입력 (기본값: 1)
  - `flexBasis` — 텍스트 입력 (px, %, auto 지원)
  - `alignSelf` — 드롭다운 (auto, flex-start, center, flex-end, stretch, baseline)
- **Codegen**: `serializeStyle()`이 이미 일반적으로 처리하므로 추가 작업 불필요

## TODO (리뷰 후 개선 사항)
- [ ] flexBasis 값 파싱/검증 강화 (px/% 단위 셀렉터 추가 고려)
- [ ] flex 컨텍스트가 아닐 때 비활성화 상태로 표시하는 UX 개선
- [ ] E2E 테스트 추가

## Test plan
- [ ] 부모가 `display: flex`인 노드 선택 시 "Flex Child" 섹션 표시 확인
- [ ] 부모가 flex가 아닌 노드 선택 시 섹션 미표시 확인
- [ ] flexGrow/flexShrink 숫자 입력 동작 확인
- [ ] flexBasis에 "auto", "100px", "50%" 입력 동작 확인
- [ ] alignSelf 드롭다운 변경 시 스타일 반영 확인
- [ ] 캔버스에서 실시간 레이아웃 변경 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)